### PR TITLE
Events between `whiteboard` and `web_client`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1939,6 +1939,12 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "@types/keyboardjs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/keyboardjs/-/keyboardjs-2.5.0.tgz",
+      "integrity": "sha512-tGU6Lz04lDNH+N3AZYIWVeBza2ZSaLlZuSkzi38zSFSuh6DgVqBdqgkX+OS+jg1vwlw5XzS5MASY44fr9C12Yg==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -4495,6 +4501,11 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "keyboardjs": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/keyboardjs/-/keyboardjs-2.6.4.tgz",
+      "integrity": "sha512-xDiNwiwH3KUqap++RFJiLAXzbvRB5Yw08xliuceOgLhM1o7g1puKKR9vWy6wp9H/Bi4VP0+SQMpiWXMWWmR6rA=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -7101,6 +7112,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true
+    },
+    "ts-key-enum": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/ts-key-enum/-/ts-key-enum-2.0.8.tgz",
+      "integrity": "sha512-ccRzCVr98faP5pKYpX0IlrPvf2VcepEFSH115CWti0eM1anh774ndXf0RlBOFecTuM103gMwaHSo0tDPlQnyNQ==",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/MadMed677/figvam#readme",
   "devDependencies": {
+    "@types/keyboardjs": "^2.5.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",
@@ -32,10 +33,12 @@
     "lerna": "^4.0.0",
     "lint-staged": "^11.2.3",
     "prettier": "2.4.1",
+    "ts-key-enum": "^2.0.8",
     "typescript": "^4.4.3"
   },
   "dependencies": {
     "@abraham/reflection": "^0.8.0",
+    "keyboardjs": "^2.6.4",
     "pixi-filters": "^4.1.5",
     "pixi.js": "^6.1.3",
     "typed-ecstasy": "^2.1.0",

--- a/packages/web_client/src/App.css
+++ b/packages/web_client/src/App.css
@@ -16,7 +16,7 @@
     --background-color--primary: #34495E;
     --background-color--accent: #F39C12;
 
-    --shadow-color--default: 236, 240, 241;
+    --shadow-color--default: 44, 62, 80;
 
     --text-color--default: #fff;
     --text-color--primary: #fff;

--- a/packages/web_client/src/App.tsx
+++ b/packages/web_client/src/App.tsx
@@ -1,24 +1,142 @@
 import React from 'react';
 import './App.css';
 
-import {Engine} from '@figvam/whiteboard';
+import Keyboard from 'keyboardjs';
+
+import {Engine, FigvamApi, InteractionMode} from '@figvam/whiteboard';
 import * as PIXI from 'pixi.js';
 
 import {Footer} from './Footer';
 
+import {CreationItem, SelectionItem} from './types/toolbar.types';
+import {
+    CreationSubType,
+    InteractionTypes,
+    SelectionSubType,
+} from '@figvam/whiteboard/types';
+
 interface IApplicationProps {
     engine: Engine;
     graphics: PIXI.Application;
+    api: FigvamApi;
 }
 
-class App extends React.PureComponent<IApplicationProps> {
+interface IApplicationState {
+    selectionItems: Array<SelectionItem>;
+    creationItems: Array<CreationItem>;
+}
+
+class App extends React.PureComponent<IApplicationProps, IApplicationState> {
     constructor(props: IApplicationProps) {
         super(props);
+
+        this.state = {
+            selectionItems: [
+                {
+                    type: SelectionSubType.Cursor,
+                    active: true,
+                },
+                {
+                    type: SelectionSubType.Hand,
+                    active: false,
+                },
+            ],
+            creationItems: [
+                {
+                    type: CreationSubType.Sticker,
+                    active: false,
+                },
+                {
+                    type: CreationSubType.Shape,
+                    active: false,
+                },
+            ],
+        };
+
+        this.setInteractionWhiteboardMode({
+            type: InteractionTypes.Selection,
+            subType: SelectionSubType.Cursor,
+        });
 
         this.tick = this.tick.bind(this);
     }
 
+    private setInteractionWhiteboardMode = (
+        interactionMode: InteractionMode,
+    ): void => {
+        this.props.api.interaction.setMode(interactionMode);
+    };
+
+    private onSelectionItemClicked = (type: 'cursor' | 'hand'): void => {
+        const updatedSelectionItems = this.state.selectionItems.map(item => {
+            if (type !== item.type) {
+                return {
+                    ...item,
+                    active: false,
+                };
+            }
+
+            this.props.api.interaction.setMode({
+                type: InteractionTypes.Selection,
+                subType:
+                    type === 'hand'
+                        ? SelectionSubType.Hand
+                        : SelectionSubType.Cursor,
+            });
+
+            return {
+                ...item,
+                active: true,
+            };
+        });
+
+        const updatedCreationItems = this.state.creationItems.map(item => ({
+            ...item,
+            active: false,
+        }));
+
+        this.setState({
+            selectionItems: updatedSelectionItems,
+            creationItems: updatedCreationItems,
+        });
+    };
+
+    private onCreationItemClicked = (type: 'shape' | 'sticker'): void => {
+        const updatedSelectionItems = this.state.selectionItems.map(item => ({
+            ...item,
+            active: false,
+        }));
+
+        const updatedCreationItems = this.state.creationItems.map(item => {
+            if (type !== item.type) {
+                return {
+                    ...item,
+                    active: false,
+                };
+            }
+
+            this.props.api.interaction.setMode({
+                type: InteractionTypes.Creation,
+                subType:
+                    type === 'sticker'
+                        ? CreationSubType.Sticker
+                        : CreationSubType.Shape,
+            });
+
+            return {
+                ...item,
+                active: true,
+            };
+        });
+
+        this.setState({
+            creationItems: updatedCreationItems,
+            selectionItems: updatedSelectionItems,
+        });
+    };
+
     componentDidMount() {
+        this.initShortcuts();
         this.props.graphics.ticker.add(this.tick);
 
         const canvasContainer = document.querySelector('#canvas_container')!;
@@ -35,12 +153,37 @@ class App extends React.PureComponent<IApplicationProps> {
     }
 
     componentWillUnmount() {
+        /** Unbind all keyboard listeners */
+        Keyboard.reset();
+
         this.props.graphics.ticker.remove(this.tick);
 
         document
             .querySelector('#canvas_container')!
             .removeChild(this.props.graphics.view);
     }
+
+    private initShortcuts = (): void => {
+        /** Select selection tool */
+        Keyboard.bind('v', e => {
+            this.onSelectionItemClicked('cursor');
+        });
+
+        /** Select hard tool */
+        Keyboard.bind('h', e => {
+            this.onSelectionItemClicked('hand');
+        });
+
+        /** Select Sticker Note tool */
+        Keyboard.bind('n', e => {
+            this.onCreationItemClicked('sticker');
+        });
+
+        /** Select Shape tool */
+        Keyboard.bind('s', e => {
+            this.onCreationItemClicked('shape');
+        });
+    };
 
     private tick() {
         this.props.engine.update(
@@ -57,7 +200,17 @@ class App extends React.PureComponent<IApplicationProps> {
                         <span onClick={console.log}>FV</span>
                     </div>
                 </div>
-                <Footer />
+                <Footer
+                    creationItems={this.state.creationItems}
+                    selectionItems={this.state.selectionItems}
+                    onClick={data => {
+                        if (data.type === 'selection') {
+                            this.onSelectionItemClicked(data.subType);
+                        } else {
+                            this.onCreationItemClicked(data.subType);
+                        }
+                    }}
+                />
             </div>
         );
     }

--- a/packages/web_client/src/App.tsx
+++ b/packages/web_client/src/App.tsx
@@ -67,7 +67,7 @@ class App extends React.PureComponent<IApplicationProps, IApplicationState> {
         this.props.api.interaction.setMode(interactionMode);
     };
 
-    private onSelectionItemClicked = (type: 'cursor' | 'hand'): void => {
+    private onSelectionItemClicked = (type: SelectionSubType): void => {
         const updatedSelectionItems = this.state.selectionItems.map(item => {
             if (type !== item.type) {
                 return {
@@ -78,10 +78,7 @@ class App extends React.PureComponent<IApplicationProps, IApplicationState> {
 
             this.props.api.interaction.setMode({
                 type: InteractionTypes.Selection,
-                subType:
-                    type === 'hand'
-                        ? SelectionSubType.Hand
-                        : SelectionSubType.Cursor,
+                subType: type,
             });
 
             return {
@@ -101,7 +98,7 @@ class App extends React.PureComponent<IApplicationProps, IApplicationState> {
         });
     };
 
-    private onCreationItemClicked = (type: 'shape' | 'sticker'): void => {
+    private onCreationItemClicked = (type: CreationSubType): void => {
         const updatedSelectionItems = this.state.selectionItems.map(item => ({
             ...item,
             active: false,
@@ -117,10 +114,7 @@ class App extends React.PureComponent<IApplicationProps, IApplicationState> {
 
             this.props.api.interaction.setMode({
                 type: InteractionTypes.Creation,
-                subType:
-                    type === 'sticker'
-                        ? CreationSubType.Sticker
-                        : CreationSubType.Shape,
+                subType: type,
             });
 
             return {
@@ -166,22 +160,22 @@ class App extends React.PureComponent<IApplicationProps, IApplicationState> {
     private initShortcuts = (): void => {
         /** Select selection tool */
         Keyboard.bind('v', e => {
-            this.onSelectionItemClicked('cursor');
+            this.onSelectionItemClicked(SelectionSubType.Cursor);
         });
 
         /** Select hard tool */
         Keyboard.bind('h', e => {
-            this.onSelectionItemClicked('hand');
+            this.onSelectionItemClicked(SelectionSubType.Hand);
         });
 
         /** Select Sticker Note tool */
         Keyboard.bind('n', e => {
-            this.onCreationItemClicked('sticker');
+            this.onCreationItemClicked(CreationSubType.Sticker);
         });
 
         /** Select Shape tool */
         Keyboard.bind('s', e => {
-            this.onCreationItemClicked('shape');
+            this.onCreationItemClicked(CreationSubType.Shape);
         });
     };
 
@@ -204,7 +198,7 @@ class App extends React.PureComponent<IApplicationProps, IApplicationState> {
                     creationItems={this.state.creationItems}
                     selectionItems={this.state.selectionItems}
                     onClick={data => {
-                        if (data.type === 'selection') {
+                        if (data.type === InteractionTypes.Selection) {
                             this.onSelectionItemClicked(data.subType);
                         } else {
                             this.onCreationItemClicked(data.subType);

--- a/packages/web_client/src/Footer.tsx
+++ b/packages/web_client/src/Footer.tsx
@@ -1,117 +1,34 @@
 import React from 'react';
 import './Footer.css';
+import {
+    ICreationMode,
+    InteractionTypes,
+    ISelectionMode,
+} from '@figvam/whiteboard/types';
 
-import {ToolbarSelectionItem, ToolbarCreationItem} from './components';
+import {ToolbarCreationItem, ToolbarSelectionItem} from './components';
+import {CreationItem, SelectionItem} from './types/toolbar.types';
 
-/** Canvas Interaction */
-interface SelectionItem {
-    /**
-     * Interaction type. It might be
-     *  - hand - canvas navigation. All clicks by whiteboard will be avoided except moving
-     *  - cursor - default mode. Clicks will be transmitted to Canvas
-     */
-    type: 'hand' | 'cursor';
+type IClick = ICreationMode | ISelectionMode;
 
-    /** Is current item active or not */
-    active: boolean;
-}
-
-/** Canvas Creation */
-interface CreationItem {
-    /**
-     * Creating type. It might be
-     *  - sticker - create `sticker` entity on whiteboard
-     *  - shape - Not supported yet
-     */
-    type: 'sticker' | 'shape';
-
-    /** Is current item active or not */
-    active: boolean;
-}
-
-interface IFooterProps {}
-interface IFooterState {
+interface IFooterProps {
+    onClick(data: IClick): void;
     selectionItems: Array<SelectionItem>;
     creationItems: Array<CreationItem>;
 }
 
-export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
-    constructor(props: IFooterProps) {
-        super(props);
-
-        this.state = {
-            selectionItems: [
-                {
-                    type: 'cursor',
-                    active: true,
-                },
-                {
-                    type: 'hand',
-                    active: false,
-                },
-            ],
-            creationItems: [
-                {
-                    type: 'sticker',
-                    active: false,
-                },
-                {
-                    type: 'shape',
-                    active: false,
-                },
-            ],
-        };
-    }
-
-    private onSelectionItemClicked = (type: 'cursor' | 'hand'): void => {
-        const updatedSelectionItems = this.state.selectionItems.map(item => {
-            if (type !== item.type) {
-                return {
-                    ...item,
-                    active: false,
-                };
-            }
-
-            return {
-                ...item,
-                active: true,
-            };
-        });
-
-        const updatedCreationItems = this.state.creationItems.map(item => ({
-            ...item,
-            active: false,
-        }));
-
-        this.setState({
-            selectionItems: updatedSelectionItems,
-            creationItems: updatedCreationItems,
+export class Footer extends React.PureComponent<IFooterProps> {
+    private onSelectionClick = (item: SelectionItem['type']): void => {
+        this.props.onClick({
+            type: InteractionTypes.Selection,
+            subType: item,
         });
     };
 
-    private onCreationItemClicked = (type: 'shape' | 'sticker'): void => {
-        const updatedSelectionItems = this.state.selectionItems.map(item => ({
-            ...item,
-            active: false,
-        }));
-
-        const updatedCreationItems = this.state.creationItems.map(item => {
-            if (type !== item.type) {
-                return {
-                    ...item,
-                    active: false,
-                };
-            }
-
-            return {
-                ...item,
-                active: true,
-            };
-        });
-
-        this.setState({
-            creationItems: updatedCreationItems,
-            selectionItems: updatedSelectionItems,
+    private onCreationClick = (item: CreationItem['type']): void => {
+        this.props.onClick({
+            type: InteractionTypes.Creation,
+            subType: item,
         });
     };
 
@@ -120,22 +37,22 @@ export class Footer extends React.PureComponent<IFooterProps, IFooterState> {
             <div className="app-footer">
                 <div className="app-footer__toolbar">
                     <div className="app-footer__toolbar--vertical-holder">
-                        {this.state.selectionItems.map(item => (
+                        {this.props.selectionItems.map(item => (
                             <ToolbarSelectionItem
                                 key={item.type}
                                 type={item.type}
-                                onClick={this.onSelectionItemClicked}
+                                onClick={this.onSelectionClick}
                                 active={item.active}
                             />
                         ))}
                     </div>
                     <div className="app-footer__divider" />
                     <div className="app-footer__toolbar--horizontal-holder">
-                        {this.state.creationItems.map(item => (
+                        {this.props.creationItems.map(item => (
                             <ToolbarCreationItem
                                 key={item.type}
                                 type={item.type}
-                                onClick={this.onCreationItemClicked}
+                                onClick={this.onCreationClick}
                                 active={item.active}
                             />
                         ))}

--- a/packages/web_client/src/components/index.tsx
+++ b/packages/web_client/src/components/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import {SelectionSubType, CreationSubType} from '@figvam/whiteboard/types';
+
 interface IToolbarSelectionItemProps {
-    type: 'hand' | 'cursor';
+    type: SelectionSubType;
     active: boolean;
-    onClick: (type: 'hand' | 'cursor') => void;
+    onClick: (type: SelectionSubType) => void;
 }
 
 export const ToolbarSelectionItem: React.FC<IToolbarSelectionItemProps> =
@@ -48,9 +50,9 @@ export const ToolbarSelectionItem: React.FC<IToolbarSelectionItemProps> =
     );
 
 interface IToolbarCreationItemProps {
-    type: 'sticker' | 'shape';
+    type: CreationSubType;
     active: boolean;
-    onClick: (type: 'sticker' | 'shape') => void;
+    onClick: (type: CreationSubType) => void;
 }
 
 export const ToolbarCreationItem: React.FC<IToolbarCreationItemProps> =

--- a/packages/web_client/src/index.tsx
+++ b/packages/web_client/src/index.tsx
@@ -18,6 +18,7 @@ ReactDOM.render(
         <App
             engine={figvamWhiteboard.engine}
             graphics={figvamWhiteboard.graphics}
+            api={figvamWhiteboard.api}
         />
     </React.StrictMode>,
     document.getElementById('root'),

--- a/packages/web_client/src/types/toolbar.types.ts
+++ b/packages/web_client/src/types/toolbar.types.ts
@@ -1,0 +1,27 @@
+import {CreationSubType, SelectionSubType} from '@figvam/whiteboard/types';
+
+/** Canvas Interaction */
+export interface SelectionItem {
+    /**
+     * Interaction type. It might be
+     *  - hand - canvas navigation. All clicks by whiteboard will be avoided except moving
+     *  - cursor - default mode. Clicks will be transmitted to Canvas
+     */
+    type: SelectionSubType;
+
+    /** Is current item active or not */
+    active: boolean;
+}
+
+/** Canvas Creation */
+export interface CreationItem {
+    /**
+     * Creating type. It might be
+     *  - sticker - create `sticker` entity on whiteboard
+     *  - shape - Not supported yet
+     */
+    type: CreationSubType;
+
+    /** Is current item active or not */
+    active: boolean;
+}

--- a/packages/whiteboard/src/core/api/figvam.api.ts
+++ b/packages/whiteboard/src/core/api/figvam.api.ts
@@ -1,0 +1,8 @@
+import {Service} from 'typedi';
+
+import {Interaction} from './interaction';
+
+@Service()
+export class FigvamApi {
+    interaction = new Interaction();
+}

--- a/packages/whiteboard/src/core/api/interaction.ts
+++ b/packages/whiteboard/src/core/api/interaction.ts
@@ -1,0 +1,47 @@
+export enum InteractionTypes {
+    Selection = 'selection',
+    Creation = 'creation',
+}
+
+export enum SelectionSubType {
+    /** Panning and Zooming on the Whiteboard. Without interaction with objects  */
+    Hand = 'hand',
+
+    /** Interaction mode. To select, drag, ... with objects  */
+    Cursor = 'cursor',
+}
+
+export enum CreationSubType {
+    /** An event to create `Sticker` object  */
+    Sticker = 'sticker',
+
+    /** An event to create `Shape` object  */
+    Shape = 'shape',
+}
+
+export interface ISelectionMode {
+    type: InteractionTypes.Selection;
+    subType: SelectionSubType;
+}
+
+export interface ICreationMode {
+    type: InteractionTypes.Creation;
+    subType: CreationSubType;
+}
+
+export type InteractionMode = ISelectionMode | ICreationMode;
+
+export class Interaction {
+    private interactionMode: InteractionMode = {
+        type: InteractionTypes.Selection,
+        subType: SelectionSubType.Hand,
+    };
+
+    setMode(interactionMode: InteractionMode): void {
+        this.interactionMode = interactionMode;
+    }
+
+    getMode(): InteractionMode {
+        return this.interactionMode;
+    }
+}

--- a/packages/whiteboard/src/graphics/graphics.interface.ts
+++ b/packages/whiteboard/src/graphics/graphics.interface.ts
@@ -1,5 +1,9 @@
 import * as PIXI from 'pixi.js';
 
+export interface GraphicsConstructor<T extends IGraphics<T>> {
+    new (id: number): T;
+}
+
 export interface IGraphics<T> {
     readonly visual: PIXI.DisplayObject;
     shouldComponentUpdate(nextProps: T): boolean;

--- a/packages/whiteboard/src/graphics/index.ts
+++ b/packages/whiteboard/src/graphics/index.ts
@@ -1,4 +1,4 @@
-export type {IGraphics} from './graphics.interface';
+export type {IGraphics, GraphicsConstructor} from './graphics.interface';
 export * from './sticker.graphics';
 export * from './canvas_background.graphics';
 export * from './selection_tool.graphics';

--- a/packages/whiteboard/src/index.ts
+++ b/packages/whiteboard/src/index.ts
@@ -24,12 +24,16 @@ import {CanvasBackgroundGraphics, StickerGraphics} from './graphics';
 import {Engine} from 'typed-ecstasy';
 import {PixiService} from './services';
 import {EntityDestroyerSystem} from './systems/entity_destroyer.system';
+import {FigvamApi} from './core/api/figvam.api';
 
 export {Engine} from 'typed-ecstasy';
+export {FigvamApi};
+export type {InteractionMode} from './core/api/interaction';
 
 interface IFigvamFactoryCreate {
     engine: Engine;
     graphics: PIXI.Application;
+    api: FigvamApi;
 }
 
 /**
@@ -92,10 +96,12 @@ export class FigvamFactory {
 
         const container = engine.getContainer();
         const pixiService = container.get(PixiService);
+        const figvamApi = container.get(FigvamApi);
 
         return {
             engine: engine,
             graphics: pixiService.getApplication(),
+            api: figvamApi,
         };
     }
 }

--- a/packages/whiteboard/src/services/event_bus.service.ts
+++ b/packages/whiteboard/src/services/event_bus.service.ts
@@ -1,6 +1,7 @@
 import {Service} from 'typedi';
 import {Signal} from 'typed-signals';
 import {Entity, ComponentConstructor} from 'typed-ecstasy';
+import {IGraphics, GraphicsConstructor} from '../graphics';
 
 interface IStickerData {
     name: 'sticker';
@@ -10,6 +11,7 @@ interface IStickerData {
             height: number;
         };
     };
+    graphics: GraphicsConstructor<IGraphics<unknown>>;
 }
 
 interface ISelectionToolData {
@@ -20,6 +22,7 @@ interface ISelectionToolData {
             height: number;
         };
     };
+    graphics: GraphicsConstructor<IGraphics<unknown>>;
 }
 
 interface ISelectionCreationToolData {
@@ -30,6 +33,7 @@ interface ISelectionCreationToolData {
             height: number;
         };
     };
+    graphics: GraphicsConstructor<IGraphics<unknown>>;
 }
 
 type IData = IStickerData | ISelectionToolData | ISelectionCreationToolData;

--- a/packages/whiteboard/src/systems/entity_creator.system.ts
+++ b/packages/whiteboard/src/systems/entity_creator.system.ts
@@ -10,11 +10,6 @@ import {
     SelectionToolComponent,
     SizeComponent,
 } from '../components';
-import {
-    SelectionGraphics,
-    SelectionToolGraphics,
-    StickerGraphics,
-} from '../graphics';
 import {SignalConnections} from 'typed-signals';
 import {EventBusService, ICreateEntity, PixiService} from '../services';
 
@@ -45,7 +40,7 @@ export class EntityCreatorSystem extends EntitySystem {
             const sticker = new Entity();
             this.engine.entities.add(sticker);
 
-            const graphics = new StickerGraphics(sticker.getId());
+            const graphics = new blueprint.graphics(sticker.getId());
             sticker.add(new SelectableComponent());
             sticker.add(new PhysicsComponent());
             sticker.add(
@@ -74,7 +69,7 @@ export class EntityCreatorSystem extends EntitySystem {
             const selection = new Entity();
             this.engine.entities.add(selection);
 
-            const graphics = new SelectionGraphics(selection.getId());
+            const graphics = new blueprint.graphics(selection.getId());
             selection.add(new SelectedComponent());
             selection.add(new SelectionComponent());
             selection.add(new SelectableComponent());
@@ -94,7 +89,7 @@ export class EntityCreatorSystem extends EntitySystem {
             const selectionTool = new Entity();
             this.engine.entities.add(selectionTool);
 
-            const graphics = new SelectionToolGraphics(selectionTool.getId());
+            const graphics = new blueprint.graphics(selectionTool.getId());
             selectionTool.add(
                 new PositionComponent(options.position.x, options.position.y),
             );

--- a/packages/whiteboard/src/systems/entity_selection.system.ts
+++ b/packages/whiteboard/src/systems/entity_selection.system.ts
@@ -8,6 +8,7 @@ import {
 } from '../components';
 import {EventBusService} from '../services';
 import {SignalConnections} from 'typed-signals';
+import {SelectionGraphics} from '../graphics';
 
 @Service()
 export class EntitySelectionSystem extends EntitySystem {
@@ -85,6 +86,7 @@ export class EntitySelectionSystem extends EntitySystem {
                             height: 0,
                         },
                     },
+                    graphics: SelectionGraphics,
                 },
             });
 

--- a/packages/whiteboard/src/systems/entity_selector.system.ts
+++ b/packages/whiteboard/src/systems/entity_selector.system.ts
@@ -8,6 +8,7 @@ import {
 } from '../components';
 import {EventBusService, ISelectionTool} from '../services';
 import {SignalConnections} from 'typed-signals';
+import {SelectionToolGraphics} from '../graphics';
 
 @Service()
 export class EntitySelectorSystem extends EntitySystem {
@@ -65,6 +66,7 @@ export class EntitySelectorSystem extends EntitySystem {
                                 height: 0,
                             },
                         },
+                        graphics: SelectionToolGraphics,
                     },
                     position: {
                         x: options.position.x,

--- a/packages/whiteboard/src/systems/mouse.system.ts
+++ b/packages/whiteboard/src/systems/mouse.system.ts
@@ -10,6 +10,8 @@ import {
 } from '../components';
 import {FigvamApi} from '../core/api/figvam.api';
 
+import {StickerGraphics} from '../graphics';
+
 import {
     CreationSubType,
     InteractionTypes,
@@ -132,6 +134,7 @@ export class MouseSystem extends EntitySystem {
     private onClickStart(e: PIXI.InteractionEvent, entity: Entity) {
         const interactionMode = this.figvamApi.interaction.getMode();
 
+        /** @todo All interaction handling must be in a different handler */
         if (
             interactionMode.type === InteractionTypes.Selection &&
             interactionMode.subType === SelectionSubType.Hand
@@ -146,6 +149,10 @@ export class MouseSystem extends EntitySystem {
             interactionMode.type === InteractionTypes.Creation &&
             interactionMode.subType === CreationSubType.Sticker
         ) {
+            /**
+             * We definitely should create entity via Factory
+             * As an example: https://lusito.github.io/typed-ecstasy/guide/data-driven/components.html
+             */
             this.eventBusService.createEntity.emit({
                 blueprint: {
                     name: 'sticker',
@@ -155,6 +162,7 @@ export class MouseSystem extends EntitySystem {
                             height: 100,
                         },
                     },
+                    graphics: StickerGraphics,
                 },
                 position: {
                     x: e.data.global.x,
@@ -162,11 +170,6 @@ export class MouseSystem extends EntitySystem {
                 },
             });
 
-            return;
-        }
-
-        // We may spawn entities only by clicking on Spawnable entities
-        if (entity.get(SpawnableComponent)) {
             return;
         }
 

--- a/packages/whiteboard/types/index.ts
+++ b/packages/whiteboard/types/index.ts
@@ -1,0 +1,8 @@
+export {
+    InteractionTypes,
+    InteractionMode,
+    ISelectionMode,
+    ICreationMode,
+    SelectionSubType,
+    CreationSubType,
+} from '../src/core/api/interaction';


### PR DESCRIPTION
The first iteration of creating events between `whiteboard` and `web_client`. It's definitely not the right implementation because we store the state of our application inside `figvam.api` but it shouldn't be there because it's just an API and core logic should read/write nothing inside API